### PR TITLE
upgrade greenwood v0.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@greenwood/cli": "~0.25.0",
+        "@greenwood/cli": "~0.26.0-alpha.0",
         "@ls-lint/ls-lint": "^1.10.0",
         "eslint": "^8.4.0",
         "puppeteer": "^13.5.2",
@@ -403,9 +403,9 @@
       "dev": true
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.25.0.tgz",
-      "integrity": "sha512-JIsgYMPTkdNgCN8GtG9Us/g1lw5V4uE9PawszyTPmEav2m0hGAfhLAhhLDAZOgrIm7DUX+k+7oc4nD6Ermt8hA==",
+      "version": "0.26.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.26.0-alpha.0.tgz",
+      "integrity": "sha512-Wp/UHtuf+DbHVnSZMycGpUPe9Z1JznEmUfqlSJTCyKtWNv0pUDShNiDhwWEqm9x6aS098IjK6ybsTkJiuLxkoQ==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -431,7 +431,8 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "rollup-plugin-terser": "^7.0.0",
-        "unified": "^9.2.0"
+        "unified": "^9.2.0",
+        "wc-compiler": "~0.3.1"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -1284,9 +1285,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1305,9 +1306,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
-      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -7077,6 +7078,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/wc-compiler": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.3.1.tgz",
+      "integrity": "sha512-hY72m2EX6WW9k8+kXzrOCxyJetaTRKmGODnW3Ftl2u1d5pOw6mXSZkBI6/5SEw07jbQK/CLs/Tem/SF2PBO0mQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0",
+        "parse5": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
@@ -7556,9 +7571,9 @@
       }
     },
     "@greenwood/cli": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.25.0.tgz",
-      "integrity": "sha512-JIsgYMPTkdNgCN8GtG9Us/g1lw5V4uE9PawszyTPmEav2m0hGAfhLAhhLDAZOgrIm7DUX+k+7oc4nD6Ermt8hA==",
+      "version": "0.26.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.26.0-alpha.0.tgz",
+      "integrity": "sha512-Wp/UHtuf+DbHVnSZMycGpUPe9Z1JznEmUfqlSJTCyKtWNv0pUDShNiDhwWEqm9x6aS098IjK6ybsTkJiuLxkoQ==",
       "dev": true,
       "requires": {
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -7584,7 +7599,8 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "rollup-plugin-terser": "^7.0.0",
-        "unified": "^9.2.0"
+        "unified": "^9.2.0",
+        "wc-compiler": "~0.3.1"
       },
       "dependencies": {
         "css-declaration-sorter": {
@@ -8166,9 +8182,9 @@
       }
     },
     "acorn": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -8179,9 +8195,9 @@
       "requires": {}
     },
     "acorn-walk": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
-      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "agent-base": {
@@ -12546,6 +12562,17 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "wc-compiler": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.3.1.tgz",
+      "integrity": "sha512-hY72m2EX6WW9k8+kXzrOCxyJetaTRKmGODnW3Ftl2u1d5pOw6mXSZkBI6/5SEw07jbQK/CLs/Tem/SF2PBO0mQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0",
+        "parse5": "^6.0.1"
       }
     },
     "web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/ProjectEvergreen/greenwood-getting-started#readme",
   "devDependencies": {
-    "@greenwood/cli": "~0.25.0",
+    "@greenwood/cli": "~0.26.0-alpha.0",
     "@ls-lint/ls-lint": "^1.10.0",
     "eslint": "^8.4.0",
     "puppeteer": "^13.5.2",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Greenwood [**v0.26.0**](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.26.0) release

## Summary of Changes
1. Upgrade latest version

## TODO
Would like to cut this over to use `HTMLElement` + WCC ideally
1. [ ] Wait for https://github.com/ProjectEvergreen/greenwood/issues/954 and `alpha.1` release
1. [ ] Keep `prerender` settings but remove puppeteer dependency
1. [ ] Validate output parity

Note: I suppose without puppeteer, this should resolve any of our [remaining Stackblitz issues](https://github.com/ProjectEvergreen/greenwood/discussions/639) 🤔 