### PR TITLE
chore/upgrade greenwood v0.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@greenwood/cli": "~0.29.0",
+        "@greenwood/cli": "~0.29.1",
         "@ls-lint/ls-lint": "^1.10.0",
         "eslint": "^8.4.0",
         "stylelint": "^13.8.0",
@@ -428,9 +428,9 @@
       "dev": true
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.1.tgz",
+      "integrity": "sha512-eCNRhcWWZpL3Zcm2yyopsEhiKhKFurquL//6Y0CDM+vMWvE+vkMUBXeaEGpd+TB396h23FlH5FT2YmoBggYCJQ==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -455,7 +455,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.9.1"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -6271,9 +6271,9 @@
       }
     },
     "node_modules/wc-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.0.tgz",
-      "integrity": "sha512-AmpkRrOVPP0SHUF/9Y9BEiHejw3K+58cjLDxj/cN3w5ptJ3ZKEICDn7v+gEmj+d7XDwwb/8PjeEzmBWjo877ew==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.1.tgz",
+      "integrity": "sha512-zdXSXeeoB6jKGV8mELFpY3fe6kxeM+i+TULqMPaP+hXHyQHUWnGAqK6juQUOFc0TVixDTcCmCuQ/GXknqXwRqA==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -6745,9 +6745,9 @@
       }
     },
     "@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.1.tgz",
+      "integrity": "sha512-eCNRhcWWZpL3Zcm2yyopsEhiKhKFurquL//6Y0CDM+vMWvE+vkMUBXeaEGpd+TB396h23FlH5FT2YmoBggYCJQ==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -6772,7 +6772,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.9.1"
       }
     },
     "@humanwhocodes/config-array": {
@@ -7240,9 +7240,9 @@
       "requires": {}
     },
     "acorn-walk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
       "dev": true
     },
     "ajv": {
@@ -11220,9 +11220,9 @@
       }
     },
     "wc-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.0.tgz",
-      "integrity": "sha512-AmpkRrOVPP0SHUF/9Y9BEiHejw3K+58cjLDxj/cN3w5ptJ3ZKEICDn7v+gEmj+d7XDwwb/8PjeEzmBWjo877ew==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.1.tgz",
+      "integrity": "sha512-zdXSXeeoB6jKGV8mELFpY3fe6kxeM+i+TULqMPaP+hXHyQHUWnGAqK6juQUOFc0TVixDTcCmCuQ/GXknqXwRqA==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/ProjectEvergreen/greenwood-getting-started#readme",
   "devDependencies": {
-    "@greenwood/cli": "~0.29.0",
+    "@greenwood/cli": "~0.29.1",
     "@ls-lint/ls-lint": "^1.10.0",
     "eslint": "^8.4.0",
     "stylelint": "^13.8.0",


### PR DESCRIPTION
Upgrade to [Greenwood v0.29.1](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.29.1) to address https://github.com/ProjectEvergreen/greenwood/issues/1185
```
➜  greenwood-getting-started git:(master) ✗ npm run build

> greenwood-getting-started@1.0.0 build
> greenwood build

-------------------------------------------------------
Welcome to Greenwood (v0.29.1) ♻️
-------------------------------------------------------
Initializing project config
Initializing project workspace contexts
Generating graph of workspace files...
building from local sources...
Running Greenwood with the build command.
pages to generate
 /blog/first-post/
 /blog/second-post/
 /
 /404/
generated page... /blog/first-post/
generated page... /blog/second-post/
generated page... /
generated page... /404/
success, done generating all pages!
bundling static assets...
optimizing static pages....
copying directory... src/assets/
copying file... src/assets/greenwood-logo.png
copying file... src/favicon.ico
copying file... .greenwood/manifest.json
```